### PR TITLE
Added methods to expose Video struct basic attributes

### DIFF
--- a/moviego.go
+++ b/moviego.go
@@ -282,6 +282,22 @@ func (V Video) GetFilename() string {
     return V.filePath
 }
 
+func (V Video) GetWidth() int64 {
+    return V.width
+}
+
+func (V Video) GetHeight() int64 {
+    return V.height
+}
+
+func (V Video) GetDuration() float64 {
+    return V.duration
+}
+
+func (V Video) GetExtension() string {
+    return V.extension
+}
+
 func Load(fileName string) (Video, error) {
     file, err := os.Stat(fileName)
     if errors.Is(err, os.ErrNotExist) && !file.IsDir() {


### PR DESCRIPTION
For one of my projects I needed to extract the dimensions and duration from the video.

I realized that these fields were present within the Video struct and therefore, without using other libraries, it is convenient to expose these 3 new methods to retrieve the field values effortlessly.

Bye :-)